### PR TITLE
Multiple uploads to glacier leave inconsistent sqlite db

### DIFF
--- a/glacier.py
+++ b/glacier.py
@@ -625,7 +625,7 @@ class App(object):
 
     def main(self):
         parser = argparse.ArgumentParser()
-        parser.add_argument('--region', default='us-east-1')
+        parser.add_argument('--region', default='eu-west-1')
         subparsers = parser.add_subparsers()
         vault_subparser = subparsers.add_parser('vault').add_subparsers()
         vault_subparser.add_parser('list').set_defaults(func=self.vault_list)


### PR DESCRIPTION
I use git-annex as a frontend for glacier-cli. If I try to upload files multiple times to glacier the sqllite db is left in an inconsistent state (Multiple rows with the same name)

I wrote a really simple mechanism to handle the case when uploading a new archive by checking the existence of the name in the db.

But I'm not fluent in python and not 100% sure how to handle the inventory cache right.
