### PR TITLE
Getting first id instead one!

### DIFF
--- a/glacier.py
+++ b/glacier.py
@@ -142,8 +142,10 @@ class Cache(object):
 
     def get_archive_id(self, vault, ref):
         try:
-            result = self._get_archive_query_by_ref(vault, ref).one()
+            result = self._get_archive_query_by_ref(vault, ref).first()
         except sqlalchemy.orm.exc.NoResultFound:
+            raise KeyError(ref)
+        if not result:
             raise KeyError(ref)
         return result.id
 


### PR DESCRIPTION
Need for multiple ids and sql alchemy doesn't crash like this:


Traceback (most recent call last):
  File "/opt/glacier-cli/glacier.py", line 732, in <module>
    App().main()
  File "/opt/glacier-cli/glacier.py", line 718, in main
    self.args.func()
  File "/opt/glacier-cli/glacier.py", line 577, in archive_retrieve
    self.archive_retrieve_one(name)
  File "/opt/glacier-cli/glacier.py", line 543, in archive_retrieve_one
    archive_id = self.cache.get_archive_id(self.args.vault, name)
  File "/opt/glacier-cli/glacier.py", line 145, in get_archive_id
    result = self._get_archive_query_by_ref(vault, ref).one()
  File "/usr/lib/python2.6/site-packages/sqlalchemy/orm/query.py", line 1260, in one
    "Multiple rows were found for one()")
sqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one()
